### PR TITLE
Fix small typo in function name

### DIFF
--- a/BIEN/vignettes/BIEN_tutorial.Rmd
+++ b/BIEN/vignettes/BIEN_tutorial.Rmd
@@ -222,7 +222,7 @@ points(cbind(Xanthium_strumarium$longitude,Xanthium_strumarium$latitude),col = "
 
 These functions begin with the prefix "BIEN_plot_" and return ecological plot data.  Functions include:
 
-1. `BIEN_plot_list_sampling_protocol` Returns the different plot sampling protocols found in the BIEN database.
+1. `BIEN_plot_list_sampling_protocols` Returns the different plot sampling protocols found in the BIEN database.
 
 2. `BIEN_plot_list_datasource` Returns the different datasources that are available in the BIEN database.  
 

--- a/tutorials/RBIEN_tutorial.Rmd
+++ b/tutorials/RBIEN_tutorial.Rmd
@@ -218,7 +218,7 @@ points(cbind(Xanthium_strumarium$longitude,Xanthium_strumarium$latitude),col="bl
 
 These functions begin with the prefix "BIEN_plot_" and return ecological plot data.  Functions include:
 
-1. `BIEN_plot_list_sampling_protocol` Returns the different plot sampling protocols found in the BIEN database.
+1. `BIEN_plot_list_sampling_protocols` Returns the different plot sampling protocols found in the BIEN database.
 
 2. `BIEN_plot_list_datasource` Returns the different datasources that are available in the BIEN database.  
 


### PR DESCRIPTION
In the tutorials the function `BIEN_list_sampling_protocols()` misses the final **s**!