### PR TITLE
Resolve issues w/ hardcoded proj4string in some ranges_* functions

### DIFF
--- a/man/BIEN_list_spatialpolygons.Rd
+++ b/man/BIEN_list_spatialpolygons.Rd
@@ -31,8 +31,9 @@ We recommend using \code{\link[rgdal]{readOGR}} to load spatial data.  Other met
 }
 \examples{
 \dontrun{
+library(rgdal)
 BIEN_ranges_species("Carnegiea gigantea")#saves ranges to the current working directory
-shape<-readOGR(dsn = ".",layer = "Carnegiea_gigantea")
+shape <- readOGR(dsn = ".",layer = "Carnegiea_gigantea")
 #spatialpolygons should be read with readOGR(), see note.
 species_list<-BIEN_list_spatialpolygons(spatialpolygons=shape)}
 }

--- a/man/BIEN_occurrence_spatialpolygons.Rd
+++ b/man/BIEN_occurrence_spatialpolygons.Rd
@@ -53,7 +53,7 @@ We recommend using \code{\link[rgdal]{readOGR}} to load spatial data
 \dontrun{
 library(rgdal)
 BIEN_ranges_species("Carnegiea gigantea")#saves ranges to the current working directory
-sp<-readOGR(dsn = ".",layer = "Carnegiea_gigantea")
+sp <- readOGR(dsn = ".",layer = "Carnegiea_gigantea")
 #SpatialPolygons should be read with readOGR().
 species_occurrences<-BIEN_occurrence_spatialpolygons(spatialpolygons=sp)}
 }

--- a/man/BIEN_phylogeny_label_nodes.Rd
+++ b/man/BIEN_phylogeny_label_nodes.Rd
@@ -49,7 +49,7 @@ other_taxa <- as.data.frame(matrix(nrow = 10,ncol = 2))
 colnames(other_taxa)<-c("taxon","species")
 other_taxa$taxon[1:5]<-"A" #Randomly assign a few species to taxon A
 other_taxa$taxon[6:10]<-"B" #Randomly assign a few species to taxon B
-tax_nodes <- 
+tax_nodes <-
  BIEN_phylogeny_label_nodes(phylogeny = phylogeny,
                             family = FALSE, genus = FALSE, other_taxa = other_taxa)
 plot.phylo(x = tax_nodes,show.tip.label = FALSE,show.node.label = TRUE)}

--- a/man/BIEN_plot_spatialpolygons.Rd
+++ b/man/BIEN_plot_spatialpolygons.Rd
@@ -49,11 +49,12 @@ US FIA coordinates have been fuzzed and swapped, for more details see: https://w
 }
 \examples{
 \dontrun{
+library(rgdal)
 BIEN_plot_state(country="United States", state="Colorado")
 BIEN_plot_state(country="United States",state= c("Colorado","California"))
 library(rgdal)
 BIEN_ranges_species("Carnegiea gigantea")#saves ranges to the current working directory
-sp<-readOGR(dsn = ".",layer = "Carnegiea_gigantea")
+sp <- readOGR(dsn = ".",layer = "Carnegiea_gigantea")
 saguaro_plot_data<-BIEN_plot_spatialpolygons(spatialpolygons=sp)}
 }
 \seealso{

--- a/man/BIEN_ranges_shapefile_to_skinny.Rd
+++ b/man/BIEN_ranges_shapefile_to_skinny.Rd
@@ -7,14 +7,18 @@
 BIEN_ranges_shapefile_to_skinny(directory, raster, skinny_ranges_file = NULL)
 }
 \arguments{
-\item{directory}{The directory where range shapefiles will be stored.  If NULL, a tempprary directoray will be used.}
+\item{directory}{The directory where range shapefiles will be stored.  If
+NULL, a tempprary directoray will be used.}
 
-\item{raster}{A raster (which must have a CRS specified) to be used for rasterizing the ranges.}
+\item{raster}{A raster (which must have a CRS specified) to be used for
+rasterizing the ranges.}
 
-\item{skinny_ranges_file}{A filename that will be used to write the skinny ranges will be written to (RDS format).  If NULL, this will not be written.}
+\item{skinny_ranges_file}{A filename that will be used to write the skinny
+ranges will be written to (RDS format).  If NULL, this will not be written.}
 }
 \value{
-Matrix containing 2 columns: 1) Species name; and 2) the raster cell number it occurs within.
+Matrix containing 2 columns: 1) Species name; and 2) the raster cell
+  number it occurs within.
 }
 \description{
 BIEN_ranges_shapefile_to_skinny converts ranges to a "skinny" format to save space.
@@ -22,8 +26,8 @@ BIEN_ranges_shapefile_to_skinny converts ranges to a "skinny" format to save spa
 \examples{
 \dontrun{
 BIEN_ranges_shapefile_to_skinny(directory = BIEN_ranges_species_bulk(species = c("Acer rubrum")),
-raster = raster::raster(crs=CRS( 
-"+proj=laea +lat_0=15 +lon_0=-80 +x_0=0 +y_0=0 +datum=WGS84 
+raster = raster::raster(crs=CRS(
+"+proj=laea +lat_0=15 +lon_0=-80 +x_0=0 +y_0=0 +datum=WGS84
  +units=m +no_defs +ellps=WGS84 +towgs84=0,0,0"),
 ext=extent(c(-5261554,5038446,-7434988,7165012 )),resolution=  c(100000,100000))
 )

--- a/man/BIEN_ranges_skinny_ranges_to_richness_raster.Rd
+++ b/man/BIEN_ranges_skinny_ranges_to_richness_raster.Rd
@@ -23,19 +23,19 @@ BIEN_ranges_skinny_ranges_to_richness_raster takes in "skinny" range data and co
 
 #Make a raster that will be used to calculate richness
 template_raster <- raster::raster(
-crs=CRS( "+proj=laea +lat_0=15 +lon_0=-80 +x_0=0 +y_0=0 +datum=WGS84 
+crs=CRS( "+proj=laea +lat_0=15 +lon_0=-80 +x_0=0 +y_0=0 +datum=WGS84
  +units=m +no_defs +ellps=WGS84 +towgs84=0,0,0"),
  ext=extent(c(-5261554,5038446,-7434988,7165012 )),resolution=  c(100000,100000))
 
 #Download ranges and convert to a "skinny" format
 skinny_ranges <- BIEN_ranges_shapefile_to_skinny(
-directory = BIEN_ranges_species_bulk(species = c("Acer rubrum"), 
+directory = BIEN_ranges_species_bulk(species = c("Acer rubrum"),
 raster = template_raster)
 
-#Convert from skinny format to richness raster                                                 
+#Convert from skinny format to richness raster
 richness_raster<- BIEN_ranges_skinny_ranges_to_richness_raster(
  skinny_ranges = skinny_ranges,raster = template_raster)
- 
+
  plot(richness_raster)
 }
 }

--- a/man/BIEN_ranges_spatialpolygons.Rd
+++ b/man/BIEN_ranges_spatialpolygons.Rd
@@ -44,9 +44,9 @@ We recommend using \code{\link[rgdal]{readOGR}} to load spatial data.  Other met
 \dontrun{
 library(rgdal)
 BIEN_ranges_species("Carnegiea gigantea")#saves ranges to the current working directory
-shape<-readOGR(dsn = ".",layer = "Carnegiea_gigantea")
+shape <- readOGR(dsn = ".",layer = "Carnegiea_gigantea")
 #spatialpolygons should be read with readOGR(), see note.
-BIEN_ranges_spatialpolygons(spatialpolygons = shape) 
+BIEN_ranges_spatialpolygons(spatialpolygons = shape)
 #Note that this will save many SpatialPolygonsDataFrames to the working directory.
 }
 }

--- a/man/BIEN_ranges_species.Rd
+++ b/man/BIEN_ranges_species.Rd
@@ -49,7 +49,7 @@ BIEN_ranges_species("Abies_lasiocarpa",temp_dir)
 
 #Reading files
 
-Abies_poly<-readOGR(dsn = temp_dir,layer = "Abies_lasiocarpa")
+Abies_poly <- readOGR(dsn = temp_dir,layer = "Abies_lasiocarpa")
 
 #Plotting files
 plot(Abies_poly)#plots the range, but doesn't mean much without any reference


### PR DESCRIPTION
This PR resolves the failures mentioned in #32. I've updated the code in `BIEN_ranges_load_species` and in `BIEN_ranges_species` to use 

`..., p4s = sf::st_crs(4326)[[2]], ....`
instead of 

`..., p4s = "+init=epsg:4326",...`

The latter was causing some errors with calls to `CRS()`, which were returning `NA`. I think it's probably because of an update to `CRS()` in the `sp` package.

I've had trouble running all of the tests to verify that everything works, but I can run individual tests related to these functions and they now produce the expected results. 

Hope this is helpful - let me know if you have any questions/comments! And thanks for making BIEN!
